### PR TITLE
Add HAML style div syntax

### DIFF
--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -34,13 +34,12 @@
 (defn base-element
   "dom element from css-style keyword like :a.class1 or :span#my-span.class"
   [node-key]
-  (let [initial-node-str (name node-key)
-        initial-tag (case (.charAt initial-node-str 0)
-                    (\# \.) "div"
-                    "")
-        node-str (str initial-tag initial-node-str)
+  (let [node-str (name node-key)
         base-idx (next-css-index node-str 0)
-        tag (if (> base-idx 0) (.substring node-str 0 base-idx) node-str)
+        tag (cond
+              (> base-idx 0) (.substring node-str 0 base-idx)
+              (zero? base-idx) "div"
+              :else node-str)
         node (.createElement js/document tag)]
     (when (>= base-idx 0)
       (loop [str (.substring node-str base-idx)]


### PR DESCRIPTION
I added a couple lines to the base-element function so that it will support HAML style div creation

``` clojure
(def my-element (template/node [:div#elem-id.elem-class]))

;; assumes this is creating a div like haml
(def my-element2 (template/node [:#elem-id.elem-class]))

(assert (== (.-outerHTML my-element) (.-outerHTML my-element2)))
```
