### PR TITLE
Crate returns native dom too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dommy
 
-Dommy is no-nonsene ClojureScript templating based on Clojure's [Hiccup](https://github.com/weavejester/hiccup/) html templating library. It is similar to [Crate](https://github.com/ibdknox/crate), but instead returns native Javascript DOM elements, rather than HTML and is much faster (3-4x, see the performance comparison test <code>dommy.template-perf-test</code>). 
+Dommy is no-nonsene ClojureScript templating based on Clojure's [Hiccup](https://github.com/weavejester/hiccup/) html templating library. It is similar to [Crate](https://github.com/ibdknox/crate), but is much faster (3-4x, see the performance comparison test <code>dommy.template-perf-test</code>). 
 
 ## Templating Usage
 


### PR DESCRIPTION
crate also returns dom nodes, dommy is just faster.
