### PR TITLE
remove dispatch on Keywords (made useless by check on js/String) in elem...

### DIFF
--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -77,9 +77,6 @@
   js/HTMLElement
   (-elem [this] this)
 
-  Keyword
-  (-elem [this] (base-element this))
-
   PersistentVector
   (-elem [this] (compound-element this))
 


### PR DESCRIPTION
cljs has no type for Keywords (not yet), meaning protocols have to check for `keyword?` on `default` or `js/String`, @ibdknox choose to do the later in c7259c983510b888a849ae54f2061a9c0d0d87ec , making the Keyword extension useless (actually it always was). 

here is a gist that shows this: https://gist.github.com/4104635
