### PR TITLE
fix use of setAttribute/getAttribute for setting className on Element in...

### DIFF
--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -5,13 +5,14 @@
   (-elem [this] "return the element representation of this"))
 
 (defn add-class! [node c]
-  (.setAttribute node "class" 
-      (if-let [cur-c (.getAttribute node "class")]
-        (str cur-c " " c)
-        c)))
+  (set! (.-className node)
+        (let [cur-c (.-className node)]
+          (if (identical? cur-c "")
+            c
+            (str cur-c " " c)))))
 
-(defn style-str [m]  
-  (->> m 
+(defn style-str [m]
+  (->> m
        (map (fn [[k v]] (str (name k) ":" (name v) ";")))
        (str/join " ")))
 
@@ -64,10 +65,10 @@
   [data]
   (let [n (base-element (first data))
         attrs (when (map? (second data)) (second data))
-        tail (drop (if attrs 2 1) data) 
+        tail (drop (if attrs 2 1) data)
         ;; Remove one level of nesting for cases like [:div [[:span][:span]]]
         tail (mapcat (fn [group] (if (satisfies? PElement group) [group] group)) tail)]
-    (when attrs 
+    (when attrs
       (add-attrs! n attrs))
     (doseq [child tail]
       (.appendChild n (node child)))

--- a/test/dommy/template_test.cljs
+++ b/test/dommy/template_test.cljs
@@ -13,17 +13,17 @@
     (assert (-> e .-tagName (= "A")))
     (assert (-> e .-textContent (= "anchor")))
     (assert (-> e (.getAttribute "href") (= "http://somelink")))
-    (assert (-> e (.getAttribute "class") (= "class1 class2"))))
+    (assert (-> e .-className (= "class1 class2"))))
   (let [e (template/base-element :div#id.class1.class2)]
     (assert (-> e .-tagName (= "DIV")))
     (assert (-> e (.getAttribute "id") (= "id")))
-    (assert (-> e (.getAttribute "class") (= "class1 class2"))))
+    (assert (-> e .-className (= "class1 class2"))))
   (let [e (template/compound-element [:div {:style {:margin-left "15px"}}])]
     (assert (-> e .-tagName (= "DIV")))
     (assert (-> e (.getAttribute "style") (= "margin-left:15px;"))))
   (let [e (template/compound-element [:div.class1 [:span#id1 "span1"] [:span#id2 "span2"]])]
     (assert (-> e .-textContent (= "span1span2")))
-    (assert (-> e (.getAttribute "class") (= "class1")))
+    (assert (-> e .-className (= "class1")))
     (assert (-> e .-childNodes .-length (= 2)))
     (assert (-> e .-innerHTML (= "<span id=\"id1\">span1</span><span id=\"id2\">span2</span>")))
     (assert (-> e .-childNodes (aget 0) .-innerHTML (= "span1")))


### PR DESCRIPTION
setAttribute to set className is unreliable on IE (depending on the version, there is also history of browser vendors juggling with the way get/setAttr work with class), the correct way to do this is to use the .className property, it is also possibly faster. 
