### PR TITLE
omit attributes that are logically false

### DIFF
--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -23,7 +23,7 @@
       :class (add-class! node v)
       :classes (doseq [c v] (add-class! node c))
       :style (.setAttribute node (name k) (style-str v))
-      (.setAttribute node (name k) v)))
+      (when v (.setAttribute node (name k) v)))) ;omit if logically false
 
 (defn next-css-index [s start-idx]
   "index of css character (#,.) in base-element. bottleneck"

--- a/test/dommy/template_test.cljs
+++ b/test/dommy/template_test.cljs
@@ -57,4 +57,14 @@
                   (.-outerHTML (template/base-element :#id1.class1))))))
   (.log js/console "PASS simple-test"))
 
+(defn ^:export boolean-test []
+  (let [e1 (template/node [:option {:selected true} "some text"])
+        e2 (template/node [:option {:selected false} "some text"])
+        e3 (template/node [:option {:selected nil} "some text"])]
+    (assert (-> e1 (.getAttribute "selected") (= "true")))
+    (assert (-> e2 (.getAttribute "selected") (nil?)))
+    (assert (-> e3 (.getAttribute "selected") (nil?)))
+    (.log js/console "PASS boolean-test")))
+
 (simple-test)
+(boolean-test)


### PR DESCRIPTION
HTML attributes that have a value are considered logically true, even if the value is the empty string.  The prior code translates an element like `[:option {:selected false} ...]` to `<option selected="false">`, which the browser interprets as true.

Omitting the attribute altogether if the value is logically false (i.e. false or nil) fixes this.

Note: this pull request only touches `template/add-attr!`, `template-compile` may require a similar change.
