### PR TITLE
allow :class string attr to specify multiple values, separated by spaces

### DIFF
--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -16,7 +16,7 @@
   (when v 
     (case k
       :class (doseq [c (.split v " ")]
-               (when (< 0 (.-length c))
+               (when (pos? (.-length c))
                  (dommy/add-class! node c)))
       :classes (doseq [c v] (dommy/add-class! node c))
       :style (.setAttribute node (name k) (style-str v))


### PR DESCRIPTION
This matches the behavior of hiccup to allow multiple classes specified in one string.  For example:

``` clojure
[:div {:class "foo bar baz"}]
```

I am aware that dommy already supports the special :classes keyword, but server-side hiccup does not, so if you want to write some code to be shared between client and server, this helps.
