### PR TITLE
allow set-attr! with a function value

### DIFF
--- a/src/dommy/attrs.cljs
+++ b/src/dommy/attrs.cljs
@@ -140,12 +140,15 @@
   ([elem k] (set-attr! (node elem) k "true"))
   ([elem k v]
    (when v
-     (doto (node elem)
-       (.setAttribute
-         (name k)
-         (if (identical? k :style)
-           (style-str v)
-           v)))))
+     (if (fn? v)
+       (doto (node elem)
+         (aset (name k) v))
+       (doto (node elem)
+         (.setAttribute
+           (name k)
+           (if (identical? k :style)
+             (style-str v)
+             v))))))
   ([elem k v & kvs]
    (assert (even? (count kvs)))
    (let [elem (node elem)]


### PR DESCRIPTION
I have found it convenient to write template functions like this:

``` clojure
(for [x (some-list)]
  [:a {:onclick #(do-something x)} "click me to operate on" x])
```

Rather than serialize data in/out of the node and have a separate way of handling events.

Thus, I submit this pull request which allows dommy to generate nodes that work this way.

A possible disadvantage to this style of coding is that it leaves a bunch of function pointers (and their scopes) in memory.  These functions should be garbage-collected with the dom node itself.

The advantage of coding this way is it's more concise and lets you store the context data of an event-handling function in a scope rather than serialized in the dom node itself.
