### PR TITLE
Compatibility problem in generated code with phantomjs

### DIFF
--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -98,9 +98,6 @@
   js/HTMLDocument
   (-elem [this] this)
 
-  js/Window
-  (-elem [this] this)
-
   PersistentVector
   (-elem [this] (compound-element this))
 
@@ -112,6 +109,13 @@
          (if (keyword? this)
            (base-element this)
            (.createTextNode js/document (str this)))))
+
+(try
+  (extend-protocol PElement
+    js/Window
+    (-elem [this] this))
+  (catch js/ReferenceError _
+    (.log js/console "PElement: js/Window not defined by browser, skipping it... (running on phantomjs?)")))
 
 (defn node [data]
   (if (satisfies? PElement data)


### PR DESCRIPTION
I'm trying to use PhantomJS in order to run unit tests headlessly, and noticed following issue when upgrading to 0.1.0 from 0.0.2.

PhantomJS apparently does not have `Window` object in global Javascript scope. This seems to cause the Javascript code with `(deftemplate ...)` definitions to throw following error on load:

`ReferenceError: Can't find variable: Window`

By looking at the generated code, the culprit seems to be following lines:

```
Window.prototype.dommy$template$PElement$ = true;
Window.prototype.dommy$template$PElement$_elem$arity$1 = (function (this$) ...
```

I tracked it back to `PElement` definition, and those lines seem to be generated by the `js/Window` entry in the definition.

Is the definition necessary? I've attached code that removes it, and at least I could not see any major issues with it. Am I missing something?
