### PR TITLE
IE fix: replace reference to js/HTMLDocument with js/Document

### DIFF
--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -95,7 +95,7 @@
   js/Text
   (-elem [this] this)
 
-  js/HTMLDocument
+  js/Document
   (-elem [this] this)
 
   js/Window


### PR DESCRIPTION
So, I noticed Dommy breaks in Internet Explorer (versions > 8, I think). This is due to references to HTMLDocument, which results in the following error:

`SCRIPT5009: 'HTMLDocument' is undefined`

I tried a quick fix and replaced HTMLDocument with Document, which seemed to do the trick. To be honest, however, this might break any number of other things... 

This seems to coincide with the pull request by @hsalokor, but just referencing another nonexistant global object. I suppose the "correct" way to fix this would be to check for existence, e.g. `if(typeof HTMLDocument !== 'undefined') { extendPrototype() }`. Anyway, as is, it's a pretty nasty bug.
