### PR TITLE
value of style attribute can be a string or a map

### DIFF
--- a/src/dommy/attrs.cljs
+++ b/src/dommy/attrs.cljs
@@ -109,10 +109,12 @@
        (remove-class! elem class))
      elem)))
 
-(defn- style-str [m]
-  (->> m
-       (map (fn [[k v]] (str (name k) ":" (name v) ";")))
-       (str/join " ")))
+(defn- style-str [x]
+  (if (string? x)
+    x
+    (->> x
+         (map (fn [[k v]] (str (name k) ":" (name v) ";")))
+         (str/join " "))))
 
 (defn set-style! [elem & kvs]
   (assert (even? (count kvs)))

--- a/test/dommy/template_test.cljs
+++ b/test/dommy/template_test.cljs
@@ -111,6 +111,20 @@
     (doseq [e [e2 e2c]] (is (-> e (.getAttribute "selected") (nil?))))
     (doseq [e [e3 e3c]] (is (-> e (.getAttribute "selected") (nil?))))))
 
+(deftest style-str
+  (let [e1 (template/node [:div {:style {:background-color "lime"}}])
+        e1c (node [:div {:style {:background-color "lime"}}])
+        e2 (template/node [:div {:style {:background-color :lime}}])
+        e2c (node [:div {:style {:background-color :lime}}])
+        e3 (template/node [:div {:style "background-color: lime"}])
+        e3c (node [:div {:style "background-color: lime"}])
+        e4 (template/node [:div {:style nil}])
+        e4c (node [:div {:style nil}])]
+    (doseq [e [e1 e1c]] (is (-> e (.getAttribute "style") (= "background-color:lime;"))))
+    (doseq [e [e2 e2c]] (is (-> e (.getAttribute "style") (= "background-color:lime;"))))
+    (doseq [e [e3 e3c]] (is (-> e (.getAttribute "style") (= "background-color: lime"))))
+    (doseq [e [e4 e4c]] (is (-> e (.getAttribute "style") (nil?))))))
+
 
 (deftemplate simple-template [[href anchor]]
   [:a.anchor {:href href} ^:text anchor])


### PR DESCRIPTION
A map is converted to a string as before, while a string is passed
on unchanged.  Fixes #33.
