### PR TITLE
Fix README: dommy.utils is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ DOM nodes are selected using macros, which expand to the correct native dom call
 ```clojure
 (:use-macros
  [dommy.macros :only [sel sel1]])
+(:require
+ [dommy.utils :as utils]
+ [dommy.core :as dommy])
 
 (sel1 :body) ; => document.body
 (sel1 :#header) ; => document.getElementById("header")


### PR DESCRIPTION
Following the example in the README:

```
"Error evaluating:" (sel ".foo") :as "dommy.utils.__GT_Array.call(null,document.getElementsByClassName(\"span10\"));\n"
#<ReferenceError: dommy is not defined>
ReferenceError: dommy is not defined
```

The solution was to require dommy.utils.
