### PR TITLE
parent function to return DOM parent node of an element

### DIFF
--- a/src/dommy/core.cljs
+++ b/src/dommy/core.cljs
@@ -65,6 +65,10 @@
     (set! (.-value elem) value)
     elem))
 
+(defn parent [elem]
+  (let [elem (template/->node-like elem)]
+    (.-parentElement elem)))
+
 (defn append!
   "append `child` to `parent`. 'parent' and 'child' should be node-like
    (work with dommy.template/->node-like). The node-like projection

--- a/test/dommy/core_test.cljs
+++ b/test/dommy/core_test.cljs
@@ -45,6 +45,14 @@
     (dommy/set-value! el "")
     (is= "" (dommy/value el))))
 
+(deftest parent
+  (let [container (node [:div])
+        el (node [:div [:div.inner "foo"]])]
+    (is= el (dommy/parent (sel1 el :.inner)))
+    (is= nil (dommy/parent el))
+    (dommy/append! container el)
+    (is= container (dommy/parent el))))
+
 (deftest append!
   (let [container (node [:div])
         el (node [:span "test"])]


### PR DESCRIPTION
There isn't a parent selector, so right now you need to call `.-parentElement` directly; this is just a simple wrapper.
