### PR TITLE
Add support for Comment in node building

### DIFF
--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -96,6 +96,9 @@
   js/Element
   (-elem [this] this)
 
+  js/Comment
+  (-elem [this] this)
+
   js/Text
   (-elem [this] this)
 

--- a/test/dommy/template_test.cljs
+++ b/test/dommy/template_test.cljs
@@ -63,7 +63,10 @@
   (let [e (first (template/html->nodes "<div><p>some-text</p></div>"))]
     (is (= "DIV" ( .-tagName e)))
     (is (= "<p>some-text</p>" (.-innerHTML e)))
-    (is (=  e (template/node e)))))
+    (is (=  e (template/node e))))
+  (let [comment (first (template/html->nodes "<!--a comment should not throw an exception-->"))]
+    (is (= "a comment should not throw an exception" (.-textContent comment)))
+    (is (= comment (template/node comment)))))
 
 (deftest nested-template-test
   ;; test html for example list form


### PR DESCRIPTION
I have a document fragment in a string, was calling `template/html->nodes` on it, but part of that string contains a `<!-- comment -->`. Dommy was throwing an exception as there was no PElement for a comment and so blew up with: _Don't know how to make node from: #<[object Comment]>_. 

Minor code change attached to add that, and a test to verify it worked.
