### PR TITLE
Extend DOM collection class *instances* with cljs protocols

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,8 @@
             [com.cemerick/austin "0.1.3"]]
   :hooks [leiningen.cljsbuild]
   :dependencies [[crate "0.2.3" :scope "dev"] ;; for perf test
-                 [com.cemerick/clojurescript.test "0.2.1"]]
+                 [com.cemerick/clojurescript.test "0.2.1"]
+                 [xnlogic/synergize "0.1.0-SNAPSHOT"]]
   :cljsbuild
   {:builds
    {:test {:source-paths ["src" "test"]

--- a/src/dommy/attrs.cljs
+++ b/src/dommy/attrs.cljs
@@ -2,6 +2,7 @@
   (:use-macros
    [dommy.macros :only [node]])
   (:require
+   synergize.browser
    [clojure.string :as str]
    [dommy.utils :refer [string-or-keyword]]))
 

--- a/src/dommy/attrs.cljs
+++ b/src/dommy/attrs.cljs
@@ -2,7 +2,7 @@
   (:use-macros
    [dommy.macros :only [node]])
   (:require
-   synergize.browser
+   [synergize.browser :refer [named-node-map]]
    [clojure.string :as str]
    [dommy.utils :refer [string-or-keyword]]))
 
@@ -144,6 +144,9 @@
   (let [pixels (style (node elem) k)]
     (when (seq pixels)
       (js/parseInt pixels))))
+
+(defn attributes [elem]
+  (named-node-map (.-attributes (node elem))))
 
 (defn set-attr!
   "Sets dom attributes on and returns `elem`.

--- a/src/dommy/core.cljs
+++ b/src/dommy/core.cljs
@@ -9,6 +9,7 @@
   (:use-macros
    [dommy.macros :only [sel sel1]])
   (:require
+   synergize.browser
    [clojure.string :as str]
    [dommy.utils :as utils]
    [dommy.attrs :as attrs]
@@ -36,7 +37,6 @@
 (def bounding-client-rect attrs/bounding-client-rect)
 (def scroll-into-view attrs/scroll-into-view)
 (def dissoc-in utils/dissoc-in)
-(def ->Array utils/->Array)
 
 (defn set-html!
   [elem html]

--- a/src/dommy/core.cljs
+++ b/src/dommy/core.cljs
@@ -176,9 +176,9 @@
    time of this `matches-pred` call (may return outdated results
    if you fuck with the DOM)"
   ([base selector]
-     (let [matches (sel (template/->node-like base) selector)]
+     (let [matches (set (sel (template/->node-like base) selector))]
        (fn [elem]
-         (-> matches (.indexOf elem) (>= 0)))))
+         (contains? matches elem))))
   ([selector]
      (matches-pred js/document selector)))
 

--- a/src/dommy/core.cljs
+++ b/src/dommy/core.cljs
@@ -9,7 +9,7 @@
   (:use-macros
    [dommy.macros :only [sel sel1]])
   (:require
-   synergize.browser
+   [synergize.browser :refer [node-list]]
    [clojure.string :as str]
    [dommy.utils :as utils]
    [dommy.attrs :as attrs]

--- a/src/dommy/macros.clj
+++ b/src/dommy/macros.clj
@@ -54,14 +54,14 @@
 (defmacro by-class
   ([base data]
      (let [data (-> data string-or-keyword (str/replace "." ""))]
-       `(dommy.utils/->Array
+       `(synergize.browser/node-list
          (.getElementsByClassName (node ~base) ~data))))
   ([data]
      `(by-class js/document ~data)))
 
 (defmacro by-tag
   ([base data]
-     `(dommy.utils/->Array
+     `(synergize.browser/node-list
        (.getElementsByTagName (node ~base) ~(string-or-keyword data))))
   ([data]
      `(by-tag js/document ~data)))
@@ -70,7 +70,7 @@
   `(.querySelector (node ~base) ~(selector-form data)))
 
 (defn query-selector-all [base data]
-  `(dommy.utils/->Array
+  `(synergize.browser/node-list
     (.querySelectorAll (node ~base) ~(selector-form data))))
 
 (defmacro sel1

--- a/src/dommy/template.cljs
+++ b/src/dommy/template.cljs
@@ -1,7 +1,8 @@
 (ns dommy.template
   (:require
    [clojure.string :as str]
-   [dommy.attrs :as attrs]))
+   [dommy.attrs :as attrs]
+   [synergize.browser :as synergize]))
 
 (def +svg-ns+ "http://www.w3.org/2000/svg")
 (def +svg-tags+ #{"svg" "g" "rect" "circle" "clipPath" "path" "line" "polygon" "polyline" "text" "textPath"})
@@ -155,4 +156,4 @@
 (defn html->nodes [html]
   (let [parent (.createElement js/document "div")]
     (.insertAdjacentHTML parent "beforeend" html)
-    (->> parent .-childNodes (.call js/Array.prototype.slice) seq)))
+    (->> parent .-childNodes synergize/node-list)))

--- a/src/dommy/utils.cljs
+++ b/src/dommy/utils.cljs
@@ -11,9 +11,6 @@
         (when-not (empty? res)
           res)))))
 
-(defn ->Array [array-like]
-  (.call js/Array.prototype.slice array-like))
-
 (defn string-or-keyword [s]
   (if (keyword? s)
     (-> (str s) (subs 1))

--- a/test/dommy/core_test.cljs
+++ b/test/dommy/core_test.cljs
@@ -413,13 +413,6 @@
     (is (= (dommy/px el :height) 0))
     (is (= (dommy/px el :width) 1))))
 
-(deftest ->Array
-  (let [array (utils/->Array (js* "{length: 2, 0: 'lol', 1: 'wut'}"))]
-    (is (instance? js/Array array))
-    (is (= (.-length array) 2))
-    (is (= (aget array 0) "lol"))
-    (is (= (aget array 1) "wut"))))
-
 (deftest bounding-client-rect
   (let [el (doto (node [:div {:style {:position "absolute" :left "100px" :top "200px"}}])
              (->> (dommy/append! js/document.body)))


### PR DESCRIPTION
This is the replacement for pr #51. I've renamed the clobber library to synergize now that it works using `specify!` and doesn't need to modify the environment anymore.

I think it's a real improvement that the browser's built in lazy data structures aren't being forced and cloned anymore.

In addition, this makes other interesting functionality possible. For instance, I added an `(attributes el)` function that returns a 'synergized' `NamedNodeMap` that acts as a transient map to element attributes. If an attribute is associated or dissociated using `assoc!` or `dissoc!`, that attribute can be set directly on the node. It also allows you to get attributes from a node using destructuring: `(let [{:keys [id class]} (attributes el)] ...)`. Similar functionality should be possible also with CSS style declarations, though I haven't looked in as much detail at those classes yet.

As before, feedback is welcome!
