### PR TITLE
create-element accepts attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+* dommy.core/create-element now accepts optional map of attributes
+* BREAKING: dommy.core/create-element no longer creates element with XML namespace. Use dommy.core/create-element-ns
+
 ## 1.0.0
 
 * Updated ClojureScript dependency to 0.0-2356

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject prismatic/dommy "1.0.1-SNAPSHOT"
+(defproject prismatic/dommy "1.1.0-SNAPSHOT"
   :clojurescript? true
   :description "Clojurescript DOM manipulation"
   :url "https://github.com/prismatic/dommy"

--- a/src/dommy/core.cljs
+++ b/src/dommy/core.cljs
@@ -292,11 +292,26 @@
 ;;; DOM Creation
 
 (defn create-element
-  ([tag]
-     (.createElement js/document (as-str tag)))
-  ([tag-ns tag]
-     (.createElementNS
-      js/document (as-str tag-ns) (as-str tag))))
+  "Creates an element for specified tag name.
+   Optionally accepts map of attributes to set on element"
+  ([tag-name]
+     (create-element tag-name nil))
+  ([tag-name attrs]
+     (let [el (.createElement js/document (as-str tag-name))]
+       (doseq [[k v] attrs]
+         (set-attr! el k v))
+       el)))
+
+(defn create-element-ns
+  "Creates an element with specified namespace URI and qualified name.
+   Optionally accepts map of attributes to set on element"
+  ([tag-ns tag-name]
+     (create-element-ns tag-ns tag-name nil))
+  ([tag-ns tag-name attrs]
+     (let [el (.createElementNS js/document (as-str tag-ns) (as-str tag-name))]
+       (doseq [[k v] attrs]
+         (set-attr! el k v))
+       el)))
 
 (defn create-text-node
   [text]

--- a/test/dommy/core_test.cljs
+++ b/test/dommy/core_test.cljs
@@ -326,6 +326,31 @@
     (is (= left 100))
     (is (= top 200))))
 
+(deftest create-element
+  (doseq [tag-name ["div" "span" "a"]
+          :let [el (dommy/create-element tag-name)]]
+    (is (= (.toUpperCase tag-name) (.-tagName el))))
+  (testing "setting attributes"
+    (let [attrs {:class "foo"
+                 :id "the-foo"
+                 :style "color:red;"
+                 :data-attribute "bar"}
+          el (dommy/create-element "div" attrs)]
+      (doseq [[attr-name attr-val] attrs]
+        (is (= attr-val (dommy/attr el attr-name)))
+        (is (= attr-val (dommy/attr el (name attr-name))))))))
+
+(deftest create-element-ns
+  (let [el (dommy/create-element-ns "http://www.w3.org/1999/xhtml" "page")]
+    (is (= "PAGE" (.-tagName el)))
+    (is (= "http://www.w3.org/1999/xhtml" (.-namespaceURI el))))
+  (testing "setting attributes"
+    (let [attrs {:title "Working with Elements"}
+          el (dommy/create-element-ns "http://www.w3.org/1999/xhtml" "page" attrs)]
+      (doseq [[attr-name attr-val] attrs]
+        (is (= attr-val (dommy/attr el attr-name)))
+        (is (= attr-val (dommy/attr el (name attr-name))))))))
+
 (deftest ->Array
   (let [array (utils/->Array (js* "{length: 2, 0: 'lol', 1: 'wut'}"))]
     (is (instance? js/Array array))


### PR DESCRIPTION
Common use-case of `create-element` is followed by `set-attr!`. This adds an
optional argument to `create-element` to pass a map of attributes to be set on the
returned element.

BREAKING API change: `create-element` no longer creates namespaced elements. A
separate `create-element-ns` function has been created to explicitly create these.
