### PR TITLE
Bug fix: vararg remove-class! should return element

### DIFF
--- a/src/dommy/core.cljs
+++ b/src/dommy/core.cljs
@@ -250,7 +250,8 @@
        elem))
   ([elem class & classes]
      (doseq [c (conj classes class)]
-       (remove-class! elem c))))
+       (remove-class! elem c))
+     elem))
 
 (defn toggle-class!
   "(toggle-class! elem class) will add-class! if elem does not have class

--- a/test/dommy/core_test.cljs
+++ b/test/dommy/core_test.cljs
@@ -90,7 +90,8 @@
     (dommy/add-class! el "test")
     (is (dommy/has-class? el "test"))
 
-    (dommy/remove-class! el "test")
+    (is (= el (dommy/remove-class! el "test"))
+        "remove-class! should return the element")
     (is (not (dommy/has-class? el "test")))
 
     (dommy/toggle-class! el "test")
@@ -110,10 +111,12 @@
 
 (deftest variadic-classes
   (let [el (ce :div)]
-    (dommy/add-class! el :foo :bar)
+    (is (= el (dommy/add-class! el :foo :bar))
+        "add-class! should return the element")
     (is (dommy/has-class? el :foo))
     (is (dommy/has-class? el :bar))
-    (dommy/remove-class! el :foo :bar)
+    (is (= el (dommy/remove-class! el :foo :bar))
+        "remove-class! should return the element")
     (is (not (dommy/has-class? el :foo)))
     (is (not (dommy/has-class? el :bar)))
     (dommy/add-class! el "this is" "four classes")


### PR DESCRIPTION
The behaviour of remove-class! was inconsistent depending on the number
of arguments passed - if removing just one class it'd return the element
allowing chaining, if removing multiple classes, because it uses doseq,
it returns nil - breaking chaining.
