### PR TITLE
Add attrs and data-attrs to get the attributes (or just the data attributes) on an element as a map.

### DIFF
--- a/src/dommy/core.cljs
+++ b/src/dommy/core.cljs
@@ -30,6 +30,28 @@
 (defn class [elem]
   (.-className elem))
 
+(defn attrs
+  "Map of all attributes on the element. Attribute names returned as keywords."
+  [elem]
+  (into {}
+   (map
+    (fn [attr]
+      (let [value (.-nodeValue attr)]
+        [(keyword (.-nodeName attr))
+         (when-not (str/blank? value) value)]))
+    (array-seq (.-attributes elem)))))
+
+(defn data-attrs
+  [elem]
+  "Map of all data attributes on the element w/o data- prefix."
+  (into {}
+   (map
+    (fn [[k v]]
+      [(keyword (str/replace-first (str k) #":data-" "")) v])
+    (filter
+     (fn [[k _]] (str/starts-with? (str k) ":data-"))
+     (attrs elem)))))
+
 (defn attr [elem k]
   (when k
     (.getAttribute elem (as-str k))))
@@ -162,7 +184,7 @@
 
 (defn remove-style!
   "Remove the style of `elem` using keywords:
-  
+
       (remove-style! elem :display :color)"
   [elem & keywords]
   (let [style (.-style elem)]


### PR DESCRIPTION
I added `attrs` and `data-attrs` to retrieve the attributes for an element as a map with keyword keys. `data-attrs` returns just the data attributes without the "data-" prefix. Seems like this would make an obvious addition to dommy, I didn't see any other way to easily retrieve all attributes for an element.

Usage:

``` html
<div id="myel" data-foo="bar" BIGKEY="BIGWORD" data-BIG="" lang="en"></div>
```

``` clojure
(attrs (sel1 [:#myel])) =>{:id "myel", :data-foo "bar", :bigkey "BIGWORD", :data-big nil, :lang "en"}
(data-attrs (sel1 [:#myel])) => {:foo "bar", :big nil}
```
