### PR TITLE
Toggle-attr! default should obtain the negation of the attr in question

### DIFF
--- a/src/dommy/core.cljs
+++ b/src/dommy/core.cljs
@@ -222,7 +222,7 @@
   "Toggles a dom attribute `k` on `elem`, optionally specifying
    the boolean value with `add?`"
   ([elem k]
-     (toggle-attr! elem k (boolean (attr elem k))))
+     (toggle-attr! elem k (not (boolean (attr elem k)))))
   ([elem k ^boolean add?]
      (if add?
        (set-attr! elem k)


### PR DESCRIPTION
## Correction in the default version of toggle-attr

while toggling attributes, the negation of the attribute truthiness currently set is to be pushed to the second version of toggle-attr

